### PR TITLE
tune(describeTable): api describeTable assept parameter with type Ydb…

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -260,11 +260,13 @@ export class Session extends EventEmitter implements ICreateSessionResult {
 
     @retryable()
     @pessimizable
-    public async describeTable(tablePath: string, operationParams?: IOperationParams): Promise<DescribeTableResult> {
+    public async describeTable(tablePath: string, operationParams?: IOperationParams,
+                               tableRequestAddititonalParams?:Omit<Ydb.Table.IDescribeTableRequest,'sessionId'|'path'|'operationParams'>): Promise<DescribeTableResult> {
         const request: Ydb.Table.IDescribeTableRequest = {
             sessionId: this.sessionId,
             path: `${this.endpoint.database}/${tablePath}`,
             operationParams,
+            ...tableRequestAddititonalParams
         };
         const response = await this.api.describeTable(request);
         const payload = getOperationPayload(response);


### PR DESCRIPTION
….Table.IDescribeTableRequest. Add third parametr with all additional parameters. Parameter { includeTableStats: true } allow receive stats info (table size, total record's count and etc)

Путем такой модификации я смог получать статистику по таблицам - размер, количество строк и тд
Например получить количество строк запросом YQL оказалось неожиданно очень дорогим ( цена линейно зависит от количества строк).

Статистика пусть и не содержит точных данных - но позволяет как то в общем ориентироваться (дешево)
