### PR TITLE
feat(executeQuery): add collectStats parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export {
     ReplicationPolicy,
     CompactionPolicy,
     ExecutionPolicy,
-    CachingPolicy
+    CachingPolicy,
+    AUTO_TX
 } from './table';
 export {getCredentialsFromEnv, getSACredentialsFromJson} from './parse-env-vars';
 export {parseConnectionString, ParsedConnectionString} from './parse-connection-string';

--- a/src/table.ts
+++ b/src/table.ts
@@ -86,7 +86,7 @@ interface INewTransaction {
     commitTx: boolean
 }
 
-const AUTO_TX: INewTransaction = {
+export const AUTO_TX: INewTransaction = {
     beginTx: {
         serializableReadWrite: {}
     },
@@ -329,6 +329,7 @@ export class Session extends EventEmitter implements ICreateSessionResult {
         txControl: IExistingTransaction | INewTransaction = AUTO_TX,
         operationParams?: IOperationParams,
         settings?: ExecDataQuerySettings,
+        collectStats?: Ydb.Table.QueryStatsCollection.Mode | null
     ): Promise<ExecuteQueryResult> {
         this.logger.trace('preparedQuery %o', query);
         this.logger.trace('parameters %o', params);
@@ -352,6 +353,7 @@ export class Session extends EventEmitter implements ICreateSessionResult {
             parameters: params,
             query: queryToExecute,
             operationParams,
+            collectStats
         };
         if (keepInCache) {
             request.queryCachePolicy = {keepInCache};


### PR DESCRIPTION
Now you can receive statistics information, for example, the number
of reading rows, affectedShards and so on.

 const data = await session.executeQuery(
            'select * from series',
            {},
            AUTO_TX,
            undefined,
            undefined,
  Ydb.Table.QueryStatsCollection.Mode.STATS_COLLECTION_BASIC
        );

        const stats_rows_read = (data.queryStats!.queryPhases!['0'].
        tableAccess!['0'].reads!.rows as Long).low;
        const affectedShards = (data.queryStats!.queryPhases!['0'].
        affectedShards as Long).low;