### PR TITLE
fix(package.json): move pino-pretty to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "long": "^4.0.0",
     "luxon": "^1.21.2",
     "pino": "^6.3.0",
+    "pino-pretty": "^3.6.1",
     "reflect-metadata": "^0.1.13",
     "yandex-cloud": "^1.4.2",
     "ydb-sdk-proto": "^0.1.0"
@@ -56,7 +57,6 @@
     "husky": "^7.0.4",
     "jest": "^27.1.0",
     "npm-run-all": "^4.1.5",
-    "pino-pretty": "^3.6.1",
     "standard-version": "^9.3.2",
     "ts-jest": "^27.0.5",
     "typescript": "^3.9.3"


### PR DESCRIPTION
When you import ydb-sdk, you was need import pino-pretty by hand