### PR TITLE
feat(auth): add helper functions to simplify driver initialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,9 @@ export {
     CachingPolicy,
     AUTO_TX
 } from './table';
-export {getCredentialsFromEnv, getSACredentialsFromJson} from './parse-env-vars';
+export {
+    getCredentialsFromEnv, getSACredentialsFromJson, getCredentialsByType, AuthType, CredentialsOptions
+} from './parse-env-vars';
 export {parseConnectionString, ParsedConnectionString} from './parse-connection-string';
 export {
     IAuthService,
@@ -49,3 +51,10 @@ export {
 } from './credentials';
 export {withRetries, RetryParameters} from './retries';
 export {YdbError, StatusCode} from './errors';
+export {
+    databaseName,
+    logger,
+    entryPoint,
+    driver,
+    initYDBdriver
+} from "./init-driver";

--- a/src/init-driver.ts
+++ b/src/init-driver.ts
@@ -1,0 +1,36 @@
+import getLogger from './logging';
+import {LevelWithSilent, Logger} from 'pino';
+import {getCredentialsByType, AuthType, CredentialsOptions} from "./parse-env-vars";
+import Driver from './driver';
+
+// for using later in your modules
+export let databaseName : string;
+export let logger : Logger;
+export let entryPoint : string;
+export let driver: Driver = null as unknown as Driver; // singleton
+
+export async function initYDBdriver(
+    type: AuthType,
+    optionsInp: Omit<CredentialsOptions, "logger">,
+    dbOptions: { entryPoint: string, databaseName: string },
+    logOptionsLevel: LevelWithSilent = 'info'
+) {
+
+    if (driver) return; // singleton
+    logger = getLogger({level: logOptionsLevel});
+    entryPoint = dbOptions.entryPoint;
+    databaseName = dbOptions.databaseName;
+
+    const options: CredentialsOptions ={...optionsInp} as CredentialsOptions ;
+    options.logger=logger;
+
+    logger.info('Start preparing driver ...');
+    const authService = getCredentialsByType(type,options);
+    driver = new Driver(entryPoint, databaseName, authService);
+
+    if (!(await driver.ready(10000))) {
+        logger.fatal(`Driver has not become ready in 10 seconds!`);
+        process.exit(1);
+    }
+    return driver;
+}

--- a/src/parse-env-vars.ts
+++ b/src/parse-env-vars.ts
@@ -47,7 +47,7 @@ function getSslCredentialsImpl(entryPoint: string, logger: Logger, useInternalCe
         logger.debug('Protocol grpc specified in entry-point, using insecure connection.');
         return undefined;
     }
-    logger.debug('No protocol specified in entry-point, using SSL connection.')
+    logger.debug('No protocol specified in entry-point, using SSL connection.');
     return getSslCert(useInternalCertificate, rootCertificates);
 }
 
@@ -55,6 +55,7 @@ export function getCredentialsFromEnv(entryPoint: string, dbName: string, logger
     function getOldSslCredentials() {
         return getSslCredentialsImpl(entryPoint, logger, false);
     }
+
     function getNewSslCredentials() {
         return getSslCredentialsImpl(entryPoint, logger, true, rootCertificates);
     }
@@ -90,3 +91,70 @@ export function getCredentialsFromEnv(entryPoint: string, dbName: string, logger
     logger.debug('Neither known env variable is set, getting token from Metadata Service');
     return new MetadataAuthService(dbName, getNewSslCredentials());
 }
+
+export type AuthType =
+    "YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" |
+    "YDB_ANONYMOUS_CREDENTIALS" |
+    "YDB_METADATA_CREDENTIALS" |
+    "YDB_IAM_TOKEN_CREDENTIALS";
+
+export interface CredentialsOptions {
+    entryPoint: string,
+    dbName: string,
+    logger: Logger,
+    serviceAccountKeyFile?: string,
+    IAMtoken?: string,
+    rootCertificates?: Buffer
+}
+
+/**
+ *
+ *  type: AuthType,                     // Auth type
+ *  options: {
+ *      entryPoint: string,             // string like "grpcs://ydb.serverless.yandexcloud.net:2135" (serverless) or ""lb.etn01lrprvnlnhv8v5kj.ydb.mdb.yandexcloud.net:2135" (dedicated)
+ *                                      // doc: https://cloud.yandex.ru/docs/ydb/reference/ydb-sdk/yc_setup
+ *                                      // you can find endpoint at web console for database
+ *      dbName: string,                 // name of database
+ *      logger: Logger,
+ *      serviceAccountKeyFile?: string, // only for YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS type: name and path of file where you store sa key token
+ *      IAMtoken?: string,              // only for YDB_IAM_TOKEN_CREDENTIALS type - IAM token
+ *      rootCertificates?: Buffer
+ *  }
+ */
+export function getCredentialsByType(type: AuthType, options: CredentialsOptions): IAuthService {
+
+    function getNewSslCredentials() {
+        return getSslCredentialsImpl(options.entryPoint, options.logger, true, options.rootCertificates);
+    }
+
+    switch (type) {
+        case 'YDB_ANONYMOUS_CREDENTIALS':
+            options.logger.debug('YDB_ANONYMOUS_CREDENTIALS , using AnonymousAuthService.');
+            return new AnonymousAuthService();
+            break;
+        case 'YDB_METADATA_CREDENTIALS':
+            options.logger.debug('YDB_METADATA_CREDENTIALS , using MetadataAuthService.');
+            return new MetadataAuthService(options.dbName, getNewSslCredentials());
+            break;
+        case 'YDB_IAM_TOKEN_CREDENTIALS':
+            options.logger.debug('YDB_IAM_TOKEN_CREDENTIALS , using TokenAuthService.');
+            if (!options.IAMtoken) {
+                options.logger.error('IAMtoken parameter is not defined, please, pass it.');
+                process.exit(500);
+            }
+            return new TokenAuthService(options.IAMtoken, options.dbName, getNewSslCredentials());
+            break;
+        case 'YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS':
+            options.logger.debug('YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS , using key file with params from that json file.');
+            if (!options.serviceAccountKeyFile) {
+                options.logger.error('serviceAccountKeyFile parameter is not defined, please, pass it.');
+                process.exit(500);
+            }
+            return new IamAuthService(getSACredentialsFromJson(options.serviceAccountKeyFile), options.dbName, getNewSslCredentials());
+            break;
+    }
+    options.logger.debug('Neither known auth type used, getting token from Metadata Service');
+    return new MetadataAuthService(options.dbName, getNewSslCredentials());
+}
+
+


### PR DESCRIPTION
Add some helper functions to simplify driver initialization:
getCredentialsByType
AuthType
initYDBdriver

Add singletone variables for use during program working:
    databaseName,
    logger,
    entryPoint,
    driver