### PR TITLE
feat: provide access to response metadata in `executeQuery`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,16 @@ jobs:
         image: cr.yandex/yc/yandex-docker-local-ydb:latest
         ports:
           - 2135:2135
+          - 8765:8765
         volumes:
           - /tmp/ydb_certs:/ydb_certs
         env:
           YDB_LOCAL_SURVIVE_RESTART: true
           YDB_USE_IN_MEMORY_PDISKS: true
         options: '-h localhost'
+
+    env:
+      YDB_SHUTDOWN_URL: http://localhost:8765/actors/kqp_proxy?force_shutdown=all
 
     steps:
     - uses: actions/checkout@v2

--- a/src/__tests__/graceful-session-close.ts
+++ b/src/__tests__/graceful-session-close.ts
@@ -1,0 +1,39 @@
+import http from 'http';
+import Driver from "../driver";
+import {destroyDriver, initDriver} from "../test-utils";
+import {sleep} from "../utils";
+
+const SHUTDOWN_URL = process.env.YDB_SHUTDOWN_URL || 'http://localhost:8765/actors/kqp_proxy?force_shutdown=all';
+
+describe('Graceful session close', () => {
+    let driver: Driver;
+    afterAll(async () => await destroyDriver(driver));
+    jest.setTimeout(60_000);
+
+    it('All sessions should be closed from the server side and be deleted upon return to the pool', async () => {
+        const PREALLOCATED_SESSIONS = 10;
+        driver = await initDriver({poolSettings: {
+            maxLimit: PREALLOCATED_SESSIONS,
+            minLimit: PREALLOCATED_SESSIONS
+        }});
+        // give time for the asynchronous session creation to finish before shutting down all existing sessions
+        await sleep(100)
+        await http.get(SHUTDOWN_URL);
+
+        let sessionsToClose = 0;
+        const promises = [];
+        for (let i = 0; i < 100; i++) {
+            const promise = driver.tableClient.withSession(async (session) => {
+                await session.executeQuery('SELECT Random(1);');
+
+                if (session.isClosing()) {
+                    sessionsToClose++;
+                }
+            });
+            promises.push(promise);
+        }
+        await Promise.all(promises);
+        expect(sessionsToClose).toBe(PREALLOCATED_SESSIONS);
+    });
+
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,9 @@ export const SESSION_KEEPALIVE_PERIOD = 60 * 1000; // 1 minute
 export enum Events {
     ENDPOINT_REMOVED = 'endpoint:removed'
 }
+
+export enum ResponseMetadataKeys {
+    RequestId = 'x-request-id',
+    ConsumedUnits = 'x-ydb-consumed-units',
+    ServerHints = 'x-ydb-server-hints'
+}


### PR DESCRIPTION
The access is provided via `onResponseMetadata` callback passed inside
`ExecuteQuerySettings` object. Also this allows to gracefully close
sessions for which server returned metadata value 'session-close' for
the 'x-ydb-server-hints' key.