### PR TITLE
fix: correctly access package.json

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,5 @@
-const pkgInfo = require('../package.json');
+const pkgPath = process.env.NODE_ENV === 'test' ? '../package.json' : '../../package.json';
+const pkgInfo = require(pkgPath);
 
 function getVersion() {
     return pkgInfo.version;


### PR DESCRIPTION
Since compiled sources moved one level deeper from the location of
package.json, the relative path has to be adjusted.