### PR TITLE
fix: correctly handle STRING type values

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -74,7 +74,7 @@ describe('Types', () => {
             it('String values', () => {
                 expect(TypedValues.string('foo')).toEqual({
                     type: {typeId: Ydb.Type.PrimitiveTypeId.STRING},
-                    value: {bytesValue: 'foo'},
+                    value: {bytesValue: Buffer.from('foo')},
                 });
                 expect(TypedValues.utf8('привет')).toEqual({
                     type: {typeId: Ydb.Type.PrimitiveTypeId.UTF8},
@@ -82,7 +82,7 @@ describe('Types', () => {
                 });
                 expect(TypedValues.yson('<a=1>[3;%false]')).toEqual({
                     type: {typeId: Ydb.Type.PrimitiveTypeId.YSON},
-                    value: {bytesValue: '<a=1>[3;%false]'},
+                    value: {bytesValue: Buffer.from('<a=1>[3;%false]')},
                 });
                 expect(TypedValues.json('{"a":1,"b":null}')).toEqual({
                     type: {typeId: Ydb.Type.PrimitiveTypeId.JSON},

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import Driver, {IDriverSettings} from "./driver";
-import {declareType, TypedData, Types} from "./types";
+import {declareType, TypedData, Types, withTypeOptions} from "./types";
 import {Column, Session, TableDescription} from "./table";
 import {withRetries} from "./retries";
 import {AnonymousAuthService} from "./credentials";
@@ -15,6 +15,9 @@ export interface IRow {
     title: string;
 }
 
+@withTypeOptions({
+    binaryStringConversion: (input: Buffer) => input.toString()
+})
 export class Row extends TypedData {
     @declareType(Types.UINT64)
     public id: number;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -19,7 +19,7 @@ export class Row extends TypedData {
     @declareType(Types.UINT64)
     public id: number;
 
-    @declareType(Types.UTF8)
+    @declareType(Types.STRING)
     public title: string;
 
     constructor(data: IRow) {
@@ -66,7 +66,7 @@ export async function createTable(session: Session) {
             ))
             .withColumn(new Column(
                 'title',
-                Types.optional(Types.UTF8),
+                Types.optional(Types.STRING),
             ))
             .withPrimaryKey('id')
     );
@@ -74,7 +74,7 @@ export async function createTable(session: Session) {
 
 export async function fillTableWithData(session: Session, rows: Row[]) {
     const query = `
-DECLARE $data AS List<Struct<id: Uint64, title: Utf8>>;
+DECLARE $data AS List<Struct<id: Uint64, title: String>>;
 
 REPLACE INTO ${TABLE}
 SELECT * FROM AS_TABLE($data);`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export const primitiveTypeToValue: Record<number, string> = {
     [Type.PrimitiveTypeId.TZ_TIMESTAMP]: 'textValue',
 };
 
-type primitive = boolean | string | number | Long | Date;
+type primitive = boolean | string | number | Long | Date | Buffer;
 
 export type StructFields = Record<string, IType>;
 
@@ -201,7 +201,7 @@ export class TypedValues {
         return TypedValues.primitive(Type.PrimitiveTypeId.DOUBLE, value);
     }
 
-    static string(value: string): ITypedValue {
+    static string(value: string | Buffer): ITypedValue {
         return TypedValues.primitive(Type.PrimitiveTypeId.STRING, value);
     }
 
@@ -345,7 +345,7 @@ const valueToNativeConverters: Record<string, (input: string|number) => any> = {
     'uint64Value': (input) => parseLong(input),
     'floatValue': (input) => Number(input),
     'doubleValue': (input) => Number(input),
-    'bytesValue': (input) => Buffer.from(input as string, 'base64').toString(),
+    'bytesValue': (input: any) => input,
     'textValue': (input) => input,
     'nullFlagValue': () => null,
 };
@@ -454,6 +454,9 @@ function objectFromValue(typeId: PrimitiveTypeId, value: unknown) {
 
 function preparePrimitiveValue(typeId: PrimitiveTypeId, value: any) {
     switch (typeId) {
+        case PrimitiveTypeId.STRING:
+        case PrimitiveTypeId.YSON:
+            return value instanceof Buffer ? value : Buffer.from(value);
         case PrimitiveTypeId.DATE:
             return Number(value) / 3600 / 1000 / 24;
         case PrimitiveTypeId.DATETIME:


### PR DESCRIPTION
Internally the most basic layer of ydb-sdk (bundle.js got from protobufs) works
with STRING values as Node.js Buffer type. To handle these values properly,
the same transformation to/from Buffer should be applied on top of basic layer.