### PR TITLE
Вuild only commonjs version of package

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -2,13 +2,10 @@
 
 package_version=`npm show . version`
 
-for target in esm cjs; do
-    cp -R certs build/$target/src/
-    [[ $target == "esm" ]] && type="module" || type="commonjs"
-    cat >build/$target/package.json <<!EOF
+cp -R certs build/src/
+cat >build/package.json <<!EOF
 {
     "version": "$package_version",
-    "type": "$type"
+    "type": "commonjs"
 }
 !EOF
-done

--- a/package.json
+++ b/package.json
@@ -2,14 +2,8 @@
   "name": "ydb-sdk",
   "version": "3.4.1",
   "description": "Node.js bindings for working with YDB API over gRPC",
-  "main": "build/cjs/src/index.js",
-  "module": "build/esm/src/index.js",
-  "exports": {
-    ".": {
-      "import": "./build/esm/src/index.js",
-      "require": "./build/cjs/src/index.js"
-    }
-  },
+  "type": "commonjs",
+  "main": "build/src/index.js",
   "files": [
     "build/**"
   ],
@@ -19,7 +13,7 @@
     "test:integration:production": "jest --config jest.config.production.js",
     "test:all": "run-p test:unit test:integration:production",
     "test": "npm run test:unit",
-    "build": "tsc -p tsconfig-esm.json && tsc -p tsconfig-cjs.json && ./fixup.sh",
+    "build": "tsc && ./fixup.sh",
     "clean": "rm -rf build",
     "prepublish": "npm run clean && npm run build",
     "release": "standard-version"

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig-base.json",
-  "compilerOptions": {
-    "target": "es2017",
-    "module": "commonjs",
-    "outDir": "build/cjs"
-  }
-}

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig-base.json",
-  "compilerOptions": {
-    "module": "esnext",
-    "outDir": "build/esm",
-    "target": "esnext"
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,10 @@
     "experimentalDecorators": true,
     "allowJs": true,
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "target": "es2017",
+    "module": "commonjs",
+    "outDir": "build"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
Сейчас пакет с sdk содержит две версии кода: c ecmascript модулями и с commonjs модулями. Рабочей является только commonjs версия, ecmascript версия содержит множество ошибок. Это приводит к импорту неработоспособного кода при использовании sdk в пакетах с type: "module" в package.json.

Самое простое решение этой проблемы - полностью удалить ecmascript версию кода. Иметь версии кода с обоими видами модулей полезно для пакетов, содержащих frontend код. Для пакета, использующегося только на backend-е в этом мало смысла.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.