### PR TITLE
fix(build): return certs back to bundle

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -3,6 +3,7 @@
 package_version=`npm show . version`
 
 for target in esm cjs; do
+    cp -R certs build/$target/src
     cat >build/$target/package.json <<!EOF
 {
     "version": "$package_version"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "test:integration:production": "jest --config jest.config.production.js",
     "test:all": "run-p test:unit test:integration:production",
     "test": "npm run test:unit",
-    "build": "tsc -p tsconfig-esm.json && tsc -p tsconfig-cjs.json",
+    "build": "tsc -p tsconfig-esm.json && tsc -p tsconfig-cjs.json && ./fixup.sh",
     "clean": "rm -rf build",
-    "prepublish": "npm run clean && npm run build && ./fixup.sh",
+    "prepublish": "npm run clean && npm run build",
     "release": "standard-version"
   },
   "keywords": [

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -19,8 +19,7 @@
     "resolveJsonModule": true
   },
   "include": [
-    "src/**/*.ts",
-    "certs"
+    "src/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Return cp of certs into bundle. Cp was deleted in 1304d4c76962ad8b26171a00f577efe560ca431c, but tsc did not include certs in the build.