### PR TITLE
feat: add data columns and sync/async index to TableIndex

### DIFF
--- a/examples/basic-example-v1/index.ts
+++ b/examples/basic-example-v1/index.ts
@@ -7,6 +7,7 @@ import {
     Logger,
     Session,
     TableDescription,
+    TableIndex,
     Types,
     withRetries,
 } from 'ydb-sdk';
@@ -73,6 +74,11 @@ async function createTables(session: Session, logger: Logger) {
             .withPrimaryKeys('series_id', 'season_id')
     );
 
+    const episodesIndex = new TableIndex('episodes_index')
+        .withIndexColumns('title')
+        .withDataColumns('air_date')
+        .withGlobalAsync(true)
+
     await session.createTable(
         EPISODES_TABLE,
         new TableDescription()
@@ -97,6 +103,7 @@ async function createTables(session: Session, logger: Logger) {
                 Types.optional(Types.DATE),
             ))
             .withPrimaryKeys('series_id', 'season_id', 'episode_id')
+            .withIndex(episodesIndex)
     );
 }
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -1095,14 +1095,34 @@ export class TableProfile implements Ydb.Table.ITableProfile {
 
 export class TableIndex implements Ydb.Table.ITableIndex {
     public indexColumns: string[] = [];
+    public dataColumns: string[] | null = null;
+    public globalIndex: Ydb.Table.IGlobalIndex|null = null;
+    public globalAsyncIndex: Ydb.Table.IGlobalAsyncIndex|null = null;
 
     constructor(public name: string) {}
 
     withIndexColumns(...indexColumns: string[]) {
-        for (const index of indexColumns) {
-            this.indexColumns.push(index);
-        }
+        this.indexColumns.push(...indexColumns);
         return this;
+    }
+
+    /** Adds [covering index](https://ydb.tech/en/docs/concepts/secondary_indexes#covering) over columns */
+    withDataColumns(...dataColumns: string[]) {
+        if(!this.dataColumns) this.dataColumns = []
+        this.dataColumns?.push(...dataColumns)
+        return this
+    }
+
+    withGlobalAsync(isAsync: boolean) {
+        if(isAsync) {
+            this.globalAsyncIndex = new Ydb.Table.GlobalAsyncIndex()
+            this.globalIndex = null
+        }
+        else {
+            this.globalAsyncIndex = null
+            this.globalIndex = new Ydb.Table.GlobalIndex()
+        }
+        return this
     }
 }
 


### PR DESCRIPTION
Add more properties to TableIndex class from proto file

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## Pull request type

Please check **one** the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What does it do?

Adds to TableIndex properties:
- withDataColumns
- withGlobalAsync
- dataColumns
- globalIndex
- globalAsyncIndex

## Why is it needed?

TableIndex doesn't have all possible properties available via GRPC

## How to test it?

run `examples/basic-example-v1/index.ts`

## Related issue(s)/PR(s)

#203 