### PR TITLE
Add support for the pool_id parameter

### DIFF
--- a/src/query/query-session-execute.ts
+++ b/src/query/query-session-execute.ts
@@ -47,6 +47,8 @@ export type IExecuteArgs = {
      */
     rowMode?: RowType,
     idempotent?: boolean,
+
+    poolId?: string,
 };
 
 export type IExecuteResult = {
@@ -107,6 +109,7 @@ export function execute(this: QuerySession, args: IExecuteArgs): Promise<IExecut
             syntax: args.syntax ?? Ydb.Query.Syntax.SYNTAX_YQL_V1,
         },
         execMode: args.execMode ?? Ydb.Query.ExecMode.EXEC_MODE_EXECUTE,
+        poolId: args.poolId,
     };
     if (args.statsMode) executeQueryRequest.statsMode = args.statsMode;
     if (args.parameters) executeQueryRequest.parameters = args.parameters;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Add support for the pool_id parameter #423.

About pool_id - https://ydb.tech/docs/ru/dev/resource-consumption-management#sozdanie-pula-resursov

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check **one** the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What does it do?

Adds the ability to specify pool_id in the query parameters from the query service

## Why is it needed?

For https://ydb.tech/docs/ru/dev/resource-consumption-management#sozdanie-pula-resursov

## How to test it?

```js
    await driver.queryClient.do({
        fn: async (session) => {
            await session.execute({
                text: `SELECT 1;`,
                poolId: 'my-pool-id'
            });
        },
    });
```

## Related issue(s)/PR(s)

#423 