### PR TITLE
FIX: Remove the context decorator in StaticCredentialsGrpcService

### DIFF
--- a/src/credentials/static-credentials-auth-service.ts
+++ b/src/credentials/static-credentials-auth-service.ts
@@ -12,7 +12,6 @@ import {IAuthService} from "./i-auth-service";
 import {HasLogger} from "../logger/has-logger";
 import {Logger} from "../logger/simple-logger";
 import {getDefaultLogger} from "../logger/get-default-logger";
-import {ensureContext} from "../context";
 
 interface StaticCredentialsAuthOptions {
     /** Custom ssl sertificates. If you use it in driver, you must use it here too */

--- a/src/credentials/static-credentials-auth-service.ts
+++ b/src/credentials/static-credentials-auth-service.ts
@@ -33,7 +33,6 @@ class StaticCredentialsGrpcService extends GrpcService<Ydb.Auth.V1.AuthService> 
         super(endpoint, 'Ydb.Auth.V1.AuthService', Ydb.Auth.V1.AuthService, sslCredentials);
     }
 
-    @ensureContext(true)
     @retryable()
     login(request: Ydb.Auth.ILoginRequest) {
         return this.api.login(request);

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -77,7 +77,7 @@ export default class Driver {
 
         if (settings.connectionString) {
             let cs = new URL(settings.connectionString);
-            endpoint = cs.origin;
+            endpoint = cs.host;
             database = cs.pathname || cs.searchParams.get('database') || '';
 
             if (!database) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check **one** the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What does it do?

This PR fixes an issue with database connection initialization in the `Driver` class.

- Removed the `@ensureContext(true)` decorator from the `login` method, which was breaking the request object and preventing authentication in YDB.
- Replaced `origin` with `host` in the `Driver` class constructor, as `origin` returned `null`, causing connection failures.

## Why is it needed?

Without this fix:
- Authentication in YDB fails because the request object is broken.
- Database connection does not establish because `origin` is `null`.

This change ensures that authentication and connection work correctly.

## How to test it?

1. Start the application with the updated code.
2. Attempt to authenticate and connect to YDB.
3. Verify that the connection initializes without errors.

## Related issue(s)/PR(s)

<!-- Please list all related issues/pull requests -->
N/A
